### PR TITLE
Upgrade to Python 3.12 and pin dependencies

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,43 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+Lawn Enforcement Band — a retro Windows 95-style desktop website for the band. The frontend simulates a Win95 desktop with draggable windows, a Winamp-style music player, a VHS/CRT video player, a boot sequence animation, and a Start menu.
+
+## Development
+
+```bash
+# Setup
+python3 -m venv venv
+source venv/bin/activate
+pip install -r requirements.txt
+
+# Run dev server (http://localhost:8000, hot reload enabled)
+python main.py
+```
+
+No build step — frontend assets in `static/` are served as-is.
+
+## Architecture
+
+- **`main.py`** — FastAPI app that mounts `static/` as a static file system. Minimal server-side logic; also configures rotating log files and reads host/port/log-level from `.env`.
+- **`static/index.html`** — Single HTML entry point; loads all JS/CSS modules.
+- **`static/js/`** — Vanilla JS modules, each responsible for one UI component:
+  - `boot.js` — Win95 boot sequence animation
+  - `desktop.js` — Window management (drag, focus, open/close)
+  - `music-player.js` — Winamp-style player
+  - `start-menu.js` — Start menu
+  - `video-player.js` — VHS/CRT video player
+- **`static/css/`** — Per-component stylesheets; `crt.css` provides scanline effects used by the video player.
+- **`vercel.json`** — SPA rewrites (all routes → `index.html`) and explicit `Content-Type` headers for audio/video assets.
+
+## Adding Media Assets
+
+- Drop MP3 files into `static/audio/` and register them in `music-player.js`.
+- Drop MP4 files into `static/video/` and reference them in `video-player.js`.
+
+## Deployment
+
+Deployed on Vercel. The `vercel.json` config handles routing and media content-type headers — no additional config needed.

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,81 @@
+# ============================================================
+# Lawn Enforcement Band — Makefile
+# Windows 95-style band website (FastAPI + vanilla JS)
+# ============================================================
+
+VENV       := venv
+PYTHON     := $(VENV)/bin/python
+PIP        := $(VENV)/bin/pip
+HOST       ?= 0.0.0.0
+PORT       ?= 8000
+LOG_LEVEL  ?= info
+
+.DEFAULT_GOAL := help
+
+# ── Help ─────────────────────────────────────────────────────
+.PHONY: help
+help: ## Show this help message
+	@echo ""
+	@echo "  Lawn Enforcement Band — Dev Commands"
+	@echo "  ====================================="
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) \
+		| awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-14s\033[0m %s\n", $$1, $$2}'
+	@echo ""
+	@echo "  Env vars: HOST (default: $(HOST))  PORT (default: $(PORT))  LOG_LEVEL (default: $(LOG_LEVEL))"
+	@echo "  Example:  make dev PORT=9000"
+	@echo ""
+
+# ── Setup ─────────────────────────────────────────────────────
+.PHONY: install
+install: ## Create virtualenv and install dependencies
+	@echo "→ Creating virtual environment..."
+	python3 -m venv $(VENV)
+	@echo "→ Installing dependencies from requirements.txt..."
+	$(PIP) install --upgrade pip -q
+	$(PIP) install -r requirements.txt
+	@echo "✓ Done. Run 'make dev' to start the server."
+
+# ── Development ───────────────────────────────────────────────
+.PHONY: dev
+dev: ## Start dev server with hot reload (http://localhost:$(PORT))
+	@echo "→ Starting Lawn Enforcement on http://$(HOST):$(PORT) ..."
+	@echo "   Hot reload: enabled | Log level: $(LOG_LEVEL)"
+	APP_HOST=$(HOST) APP_PORT=$(PORT) LOG_LEVEL=$(LOG_LEVEL) $(PYTHON) main.py
+
+# ── Logs ──────────────────────────────────────────────────────
+.PHONY: logs
+logs: ## Tail the application log file
+	@echo "→ Tailing logs/app.log (Ctrl+C to stop)..."
+	tail -f logs/app.log
+
+.PHONY: logs-clear
+logs-clear: ## Delete all log files in logs/
+	@echo "→ Clearing log files..."
+	rm -f logs/*.log logs/*.log.*
+	@echo "✓ Log files cleared."
+
+# ── Utilities ─────────────────────────────────────────────────
+.PHONY: freeze
+freeze: ## Update requirements.txt from current venv
+	@echo "→ Freezing dependencies to requirements.txt..."
+	$(PIP) freeze > requirements.txt
+	@echo "✓ requirements.txt updated."
+
+.PHONY: clean
+clean: ## Remove virtualenv, logs, and Python cache files
+	@echo "→ Removing venv, logs, and __pycache__..."
+	rm -rf $(VENV) logs __pycache__ .pytest_cache
+	find . -name "*.pyc" -delete
+	@echo "✓ Clean."
+
+.PHONY: info
+info: ## Show environment info
+	@echo ""
+	@echo "  Project : Lawn Enforcement Band"
+	@echo "  Python  : $$(python3 --version)"
+	@echo "  Venv    : $(VENV)"
+	@echo "  Host    : $(HOST)"
+	@echo "  Port    : $(PORT)"
+	@echo "  Static  : ./static/"
+	@echo "  Logs    : ./logs/app.log"
+	@echo ""

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@
 VENV       := venv
 PYTHON     := $(VENV)/bin/python
 PIP        := $(VENV)/bin/pip
+PYTHON_BIN ?= /opt/homebrew/bin/python3.12
 HOST       ?= 0.0.0.0
 PORT       ?= 8000
 LOG_LEVEL  ?= info
@@ -28,8 +29,8 @@ help: ## Show this help message
 # ── Setup ─────────────────────────────────────────────────────
 .PHONY: install
 install: ## Create virtualenv and install dependencies
-	@echo "→ Creating virtual environment..."
-	python3 -m venv $(VENV)
+	@echo "→ Creating virtual environment (Python 3.12)..."
+	$(PYTHON_BIN) -m venv $(VENV)
 	@echo "→ Installing dependencies from requirements.txt..."
 	$(PIP) install --upgrade pip -q
 	$(PIP) install -r requirements.txt

--- a/README.md
+++ b/README.md
@@ -26,13 +26,32 @@ levensailor
 
 ### Local Setup
 
+A `Makefile` is included for convenience:
+
 ```bash
-cd lawnenforcement
-python3 -m venv venv
-source venv/bin/activate
-pip install -r requirements.txt
-python main.py
+make install   # create virtualenv and install dependencies
+make dev       # start dev server at http://localhost:8000 (hot reload enabled)
 ```
+
+Override defaults with env vars:
+
+```bash
+make dev PORT=9000 LOG_LEVEL=debug
+```
+
+All available commands:
+
+| Command | Description |
+|---|---|
+| `make install` | Create venv and install deps |
+| `make dev` | Start dev server with hot reload |
+| `make logs` | Tail `logs/app.log` |
+| `make logs-clear` | Delete log files |
+| `make freeze` | Update `requirements.txt` from current venv |
+| `make clean` | Remove venv, logs, and cache |
+| `make info` | Print env/config summary |
+
+Run `make help` to see all commands with descriptions.
 
 The site will be available at **http://localhost:8000**.
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ levensailor
 
 ### Prerequisites
 
-- Python 3.8+
+- Python 3.12+
 - pip
 
 ### Local Setup

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,14 @@
-fastapi
-uvicorn
-python-dotenv
+annotated-doc==0.0.4
+annotated-types==0.7.0
+anyio==4.12.1
+click==8.3.1
+fastapi==0.135.1
+h11==0.16.0
+idna==3.11
+pydantic==2.12.5
+pydantic_core==2.41.5
+python-dotenv==1.2.2
+starlette==0.52.1
+typing-inspection==0.4.2
+typing_extensions==4.15.0
+uvicorn==0.42.0


### PR DESCRIPTION
## Summary

- Upgrades runtime to Python 3.12 (3.12.13)
- Pins all dependencies with exact versions in `requirements.txt` (fastapi 0.135.1, uvicorn 0.42.0, pydantic 2.12.5, etc.)
- Updates README prerequisite from Python 3.8+ to 3.12+
- Python 3.8 was End Of LIfe in 2024: https://devguide.python.org/versions/

## Test plan

- [ ] `python3.12 -m venv venv && source venv/bin/activate`
- [ ] `pip install -r requirements.txt` — all packages install cleanly
- [ ] `python main.py` — server starts on http://localhost:8000

```
❯  ~/code/lawnenforcementband [python-3.12-upgrade] ❯ make help

  Lawn Enforcement Band — Dev Commands
  =====================================
  help           Show this help message
  install        Create virtualenv and install dependencies
  dev            Start dev server with hot reload (http://localhost:$(PORT))
  logs           Tail the application log file
  logs-clear     Delete all log files in logs/
  freeze         Update requirements.txt from current venv
  clean          Remove virtualenv, logs, and Python cache files
  info           Show environment info

  Env vars: HOST (default: 0.0.0.0)  PORT (default: 8000)  LOG_LEVEL (default: info)
  Example:  make dev PORT=9000
```